### PR TITLE
Limit the memcpy for endpoint descriptors to 7 bytes (USB_DT_ENDPOINT_SIZE)

### DIFF
--- a/lib/usb/usb_standard.c
+++ b/lib/usb/usb_standard.c
@@ -114,7 +114,7 @@ static uint16_t build_config_descriptor(usbd_device *usbd_dev,
 			for (k = 0; k < iface->bNumEndpoints; k++) {
 				const struct usb_endpoint_descriptor *ep =
 				    &iface->endpoint[k];
-				memcpy(buf, ep, count = MIN(len, ep->bLength));
+				memcpy(buf, ep, count = MIN(USB_DT_ENDPOINT_SIZE, MIN(len, ep->bLength)));
 				buf += count;
 				len -= count;
 				total += count;


### PR DESCRIPTION
Without this, if you specify a `.bLength` > 7, it will read the pointer bytes from `.extra`, which as far as the USB host is concerned, is garbage.

With this patch, you are now able to specify endpoint descriptors with, for example, 9 bytes length, which is useful for feedback endpoints, which have the two extra `.bRefresh` and `.bSynchAddress` bytes. You can do this by pointing the `.extra` field to a memory location that starts with those two bytes, and any other extra descriptors that you might want to use.

Here is an example:

```C
static const struct {
	uint8_t bRefresh;
	uint8_t bSynchAddress;
	struct usb_audio_stream_audio_endpoint_descriptor audio_ep;
} __attribute__((packed)) audio_iso_playback_endp = {
	.bRefresh = 0,
	.bSynchAddress = 0x81,
	.audio_ep = {
		.bLength = sizeof(struct usb_audio_stream_audio_endpoint_descriptor),
		.bDescriptorType = USB_AUDIO_DT_CS_ENDPOINT,
		.bDescriptorSubtype = 0x01,
		.bmAttributes = 0x01,
		.bLockDelayUnits = 0,
		.wLockDelay = 0
	}
};

static const struct usb_endpoint_descriptor iso_playback_endpoints[] = {{
	.bLength = USB_DT_ENDPOINT_SIZE + 2, // 9 bytes
	.bDescriptorType = USB_DT_ENDPOINT,
	.bEndpointAddress = 0x01,
	.bmAttributes = USB_ENDPOINT_ATTR_ISOCHRONOUS | USB_ENDPOINT_ATTR_ASYNC | USB_ENDPOINT_ATTR_DATA,
	.wMaxPacketSize = AUDIO_ENDPOINT_SIZE,
	.bInterval = 1,

	.extra = &audio_iso_playback_endp,
	.extralen = sizeof(audio_iso_playback_endp)
}, {
	.bLength = USB_DT_ENDPOINT_SIZE,
	.bDescriptorType = USB_DT_ENDPOINT,
	.bEndpointAddress = 0x81,
	.bmAttributes = USB_ENDPOINT_ATTR_ISOCHRONOUS | USB_ENDPOINT_ATTR_ASYNC | USB_ENDPOINT_ATTR_FEEDBACK,
	.wMaxPacketSize = 3,
	.bInterval = 10
}};
```
